### PR TITLE
Emit error/timeout events on the subscription instance

### DIFF
--- a/lib/stan.js
+++ b/lib/stan.js
@@ -641,14 +641,14 @@ Stan.prototype.subscribe = function(subject, qGroup, options) {
 
     if (typeof subject !== 'string' || subject.length === 0) {
         process.nextTick(() => {
-            this.emit('error', new Error(BAD_SUBJECT));
+            retVal.emit('error', new Error(BAD_SUBJECT));
         });
         return retVal;
     }
 
     if (this.isClosed()) {
         process.nextTick(() => {
-            this.emit('error', new Error(CONN_CLOSED));
+            retVal.emit('error', new Error(CONN_CLOSED));
         });
         return retVal;
     }
@@ -677,9 +677,10 @@ Stan.prototype.subscribe = function(subject, qGroup, options) {
     this.nc.requestOne(this.subRequests, Buffer.from(sr.serializeBinary()), this.options.connectTimeout, (msg) => {
         if (msg instanceof nats.NatsError) {
             if (msg.code === nats.REQ_TIMEOUT) {
-                this.emit('timeout', SUB_REQ_TIMEOUT);
+                const err = new nats.NatsError(SUB_REQ_TIMEOUT, SUB_REQ_TIMEOUT, msg);
+                retVal.emit('timeout', err);
             } else {
-                this.emit('error', msg);
+                retVal.emit('error', msg);
             }
             return;
         }


### PR DESCRIPTION
Fixes: #110 

# Description

Help applications determine which of their subscription attempts are failing, so that they could retry, etc. 