### PR TITLE
fix: throw proper Error object for CONNECT_REQ_TIMEOUT

### DIFF
--- a/lib/stan.js
+++ b/lib/stan.js
@@ -323,8 +323,7 @@ Stan.prototype.createConnection = function() {
             if (msg instanceof nats.NatsError) {
                 let err = msg;
                 if (msg.code === nats.REQ_TIMEOUT) {
-                    err = new Error(CONNECT_REQ_TIMEOUT);
-                    err.chainedError = msg;
+                    err = new nats.NatsError(CONNECT_REQ_TIMEOUT, CONNECT_REQ_TIMEOUT, err);
                 }
                 this.closeWithError('error', err);
                 return;

--- a/lib/stan.js
+++ b/lib/stan.js
@@ -323,7 +323,8 @@ Stan.prototype.createConnection = function() {
             if (msg instanceof nats.NatsError) {
                 let err = msg;
                 if (msg.code === nats.REQ_TIMEOUT) {
-                    err = CONNECT_REQ_TIMEOUT;
+                    err = new Error(CONNECT_REQ_TIMEOUT);
+                    err.chainedError = msg;
                 }
                 this.closeWithError('error', err);
                 return;


### PR DESCRIPTION
The `REQ_TIMEOUT` error is currently throwing a string as an error, causing some of our error handlers to ignore it.

This PR makes it a proper Error object and attaches the original `NatsError`.