### PR TITLE
Performance Improvement: Eliminate calls to `toByteArray` when deserialise proto-buf

### DIFF
--- a/lib/stan.js
+++ b/lib/stan.js
@@ -229,10 +229,6 @@ Stan.prototype.initState = function() {
     this.subMap = {};
 };
 
-Buffer.prototype.toByteArray = function() {
-    return Array.prototype.slice.call(this, 0);
-};
-
 /**
  * Connect event - emitted when the streaming protocol connection sequence  has
  * completed and the client is ready to process requests.
@@ -295,7 +291,7 @@ Stan.prototype.createConnection = function() {
         this.pingInbox = nats.createInbox();
         this.pingSubscription = this.nc.subscribe(this.pingInbox, (msg) => {
             if (msg) {
-                const pingResponse = proto.PingResponse.deserializeBinary(Buffer.from(msg, 'binary').toByteArray());
+                const pingResponse = proto.PingResponse.deserializeBinary(Buffer.from(msg, 'binary'));
                 const err = pingResponse.getError();
                 if (err) {
                     this.closeWithError('connection_lost', err);
@@ -329,7 +325,7 @@ Stan.prototype.createConnection = function() {
                 return;
             }
 
-            const cr = proto.ConnectResponse.deserializeBinary(Buffer.from(msg, 'binary').toByteArray());
+            const cr = proto.ConnectResponse.deserializeBinary(Buffer.from(msg, 'binary'));
             if (cr.getError() !== "") {
                 this.closeWithError('error', cr.getError());
                 return;
@@ -481,7 +477,7 @@ Stan.prototype.close = function() {
                 // if we get an error here, we simply show it in the close notification as there's not much we can do here.
                 closeError = msgOrError;
             } else {
-                const cr = proto.CloseResponse.deserializeBinary(Buffer.from(msgOrError, 'binary').toByteArray());
+                const cr = proto.CloseResponse.deserializeBinary(Buffer.from(msgOrError, 'binary'));
                 const err = cr.getError();
                 if (err && err.length > 0) {
                     // if the protocol returned an error there's nothing for us to handle, pass it as an arg to close notification.
@@ -510,7 +506,7 @@ Stan.prototype.close = function() {
 Stan.prototype.processAck = function() {
     return (msg) => {
         //noinspection JSUnresolvedVariable
-        const pa = proto.PubAck.deserializeBinary(Buffer.from(msg, 'binary').toByteArray());
+        const pa = proto.PubAck.deserializeBinary(Buffer.from(msg, 'binary'));
         const guid = pa.getGuid();
         const a = this.removeAck(guid);
         if (a && a.ah) {
@@ -685,7 +681,7 @@ Stan.prototype.subscribe = function(subject, qGroup, options) {
             return;
         }
         //noinspection JSUnresolvedVariable
-        const r = proto.SubscriptionResponse.deserializeBinary(Buffer.from(msg, 'binary').toByteArray());
+        const r = proto.SubscriptionResponse.deserializeBinary(Buffer.from(msg, 'binary'));
         const err = r.getError();
         if (err && err.length !== 0) {
             retVal.emit('error', new Error(err));
@@ -837,7 +833,7 @@ Subscription.prototype.closeOrUnsubscribe = function(doClose) {
             return;
         }
         //noinspection JSUnresolvedVariable
-        const r = proto.SubscriptionResponse.deserializeBinary(Buffer.from(msg, 'binary').toByteArray());
+        const r = proto.SubscriptionResponse.deserializeBinary(Buffer.from(msg, 'binary'));
         err = r.getError();
         if (err && err.length > 0) {
             this.emit('error', new Error(r.getError()));
@@ -859,7 +855,7 @@ Stan.prototype.processMsg = function() {
         const sub = this.subMap[subject];
         try {
             //noinspection JSUnresolvedVariable
-            const m = proto.MsgProto.deserializeBinary(Buffer.from(rawMsg, 'binary').toByteArray());
+            const m = proto.MsgProto.deserializeBinary(Buffer.from(rawMsg, 'binary'));
             if (sub === undefined || !this.nc) {
                 return;
             }


### PR DESCRIPTION
Protobuf can accept `Buffer` as input for `deserializeBinary`.

In a simple benchmark I did locally:
* ruby code, while true - send message 12kb size
* node code - subscribe to message (queue group, durable) 

The node process was at 100% CPU, after this change it’s reduced to 10% peak.

And bench-sub results:

| messages count | master - total time | master - msgs/sec | PR - total time | PR - msgs/sec |
| -------------- | ---------------------- | -------------------- | ----------------------- | --------------------- |
| 10,000 | 232ms | 43,103 | 163ms | 61,350 |
| 100,000 | 1,185ms | 84,388 | 790ms | 126,582 |
| 1,000,000 | 9,303ms | 107,492 | 5,999ms | 166,7222 |

all benchmarks running on:
node v10.15.3
MacBook Pro (15-inch, 2018)