### PR TITLE
Removed unused sub argument for ready event listener callback in two examples.

### DIFF
--- a/examples/stan-sub.js
+++ b/examples/stan-sub.js
@@ -35,8 +35,8 @@ stan.on('connect', function() {
     subscription.on('unsubscribed', () => {
         console.log(`unsubscribed to ${subject}`);
     });
-    subscription.on('ready', (sub) => {
-        console.log(`subscribed to ${sub.subject}`);
+    subscription.on('ready', () => {
+        console.log(`subscribed to ${subject}`);
     });
     subscription.on('message', (msg) => {
         console.log(msg.getSubject(), `[${msg.getSequence()}]`, msg.getData());

--- a/examples/stan-worker.js
+++ b/examples/stan-worker.js
@@ -52,7 +52,7 @@ sc.on('connect', function() {
     subscription.on('unsubscribed', () => {
         console.log(`unsubscribed to ${subject}`);
     });
-    subscription.on('ready', (sub) => {
+    subscription.on('ready', () => {
         console.log(`subscribed to ${subject}`);
     });
     subscription.on('message', (msg) => {


### PR DESCRIPTION
Small change to update the examples.