### PR TITLE
forwarding of newer nats connection properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ jspm_packages
 
 typings/
 
+.DS_Store
+

--- a/.npmignore
+++ b/.npmignore
@@ -26,3 +26,4 @@ tsconfig.json
 TODO
 Makefile
 test/
+tstest/

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The NATS Authors
+ * Copyright 2016-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,27 +40,36 @@ export interface StanOptions extends ClientOpts {
 	nc?: nats.Client
 }
 
-// these are standard node-nats options, some are omitted until
-// nats-streaming-server supports them. Others like encoding
-// must always be set to binary.
+// these are standard node-nats options, some are omitted
+// like json, noEcho, preserveBuffers because they don't
+// make sense in nats-streaming. Encoding is here, however
+// it's value must always be set to binary as the client
+// exchanges protobuf messages
 export interface ClientOpts {
-    url?: string,
-    user?: string,
-    pass?: string,
-    verbose?: boolean,
-    pedantic?: boolean,
-    reconnect?: boolean,
+    encoding?: BufferEncoding,
+    maxPingOut?: number,
     maxReconnectAttempts?: number,
+    name?: string,
+    nkey?: string,
+    noRandomize?: boolean,
+    nonceSigner?: Function,
+    pass?: string,
+    pedantic?: boolean,
+    pingInterval?: number,
+    reconnect?: boolean,
     reconnectTimeWait?: number,
     servers?: Array<string>,
-    noRandomize?: boolean,
     tls?: boolean | tls.TlsOptions,
-    name?: string,
-    yieldTime?: number,
-    waitOnFirstConnect?: boolean,
     token?: string,
-    pingInterval?: number,
-    maxPingOut?: number,
+    tokenHandler?: Function,
+    url?: string,
+    useOldRequestStyle?: boolean,
+    user?: string,
+    userCreds?: string,
+    userJWT?: string | Function,
+    verbose?: boolean,
+    waitOnFirstConnect?: boolean,
+    yieldTime?: number
 }
 
 

--- a/lib/stan.js
+++ b/lib/stan.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 The NATS Authors
+ * Copyright 2016-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/lib/stan.js
+++ b/lib/stan.js
@@ -31,13 +31,14 @@ const url = require('url')
 /**
  * Constants
  */
-const VERSION = '0.2.6'
+const VERSION = require('../package').version
 const DEFAULT_PORT = 4222
 const DEFAULT_PRE = 'nats://localhost:'
 const DEFAULT_URI = DEFAULT_PRE + DEFAULT_PORT
 const DEFAULT_DISCOVER_PREFIX = '_STAN.discover'
 const DEFAULT_ACK_PREFIX = '_STAN.acks'
 const DEFAULT_CONNECT_WAIT = 1000 * 2
+const DEFAULT_MAX_RECONNECT_ATTEMPTS = -1
 
 const DEFAULT_MAX_IN_FLIGHT = 16384
 const DEFAULT_ACK_WAIT = 30 * 1000
@@ -87,6 +88,10 @@ function Stan (clusterID, clientID, opts) {
   this.closeRequests = null // subject for close requests
 
   this.parseOptions(opts)
+  // allow testing options
+  if (opts && opts.test_opts) {
+    return this
+  }
   this.initState()
   this.createConnection()
   return this
@@ -122,15 +127,15 @@ Stan.prototype.isClosed = function () {
  */
 Stan.prototype.parseOptions = function (opts) {
   const options = this.options = {
-    url: DEFAULT_URI,
-    connectTimeout: DEFAULT_CONNECT_WAIT,
     ackTimeout: DEFAULT_ACK_WAIT,
+    connectTimeout: DEFAULT_CONNECT_WAIT,
     discoverPrefix: DEFAULT_DISCOVER_PREFIX,
     maxPubAcksInflight: DEFAULT_MAX_IN_FLIGHT,
+    maxReconnectAttempts: DEFAULT_MAX_RECONNECT_ATTEMPTS,
     stanEncoding: 'utf8',
-    stanPingInterval: DEFAULT_PING_INTERVAL,
     stanMaxPingOut: DEFAULT_PING_MAXOUT,
-    maxReconnectAttempts: -1
+    stanPingInterval: DEFAULT_PING_INTERVAL,
+    url: DEFAULT_URI
   }
 
   if (opts === undefined) {
@@ -144,46 +149,60 @@ Stan.prototype.parseOptions = function (opts) {
       options.url = DEFAULT_PRE + opts.port
     }
 
-    this.assignOption(opts, 'discoverPrefix')
-    this.assignOption(opts, 'nc')
-    this.assignOption(opts, 'connectTimeout')
     this.assignOption(opts, 'ackTimeout')
+    this.assignOption(opts, 'connectTimeout')
+    this.assignOption(opts, 'discoverPrefix')
     this.assignOption(opts, 'maxPubAcksInflight')
+    this.assignOption(opts, 'nc')
     this.assignOption(opts, 'stanEncoding')
-    this.assignOption(opts, 'stanPingInterval')
     this.assignOption(opts, 'stanMaxPingOut')
+    this.assignOption(opts, 'stanPingInterval')
 
-    // node-nats does takes a bunch of other options
-    // we simply forward them, as node-nats is used
-    // underneath.
-    this.assignOption(opts, 'url')
-    this.assignOption(opts, 'uri', 'url')
-    this.assignOption(opts, 'user')
-    this.assignOption(opts, 'pass')
-    this.assignOption(opts, 'token')
-    this.assignOption(opts, 'tokenHandler')
-    this.assignOption(opts, 'password', 'pass')
-    this.assignOption(opts, 'verbose')
-    this.assignOption(opts, 'pedantic')
-    this.assignOption(opts, 'reconnect')
+    // node-nats does takes a bunch of other options we simply forward them, as node-nats is used underneath.
+    // Options like json, noEcho, preserveBuffers are omitted because they don't make sense
+    this.assignOption(opts, 'encoding')
+    this.assignOption(opts, 'maxPingOut')
     this.assignOption(opts, 'maxReconnectAttempts')
+    this.assignOption(opts, 'name')
+    this.assignOption(opts, 'nkey')
+    this.assignOption(opts, 'noRandomize')
+    this.assignOption(opts, 'nonceSigner')
+    this.assignOption(opts, 'pass')
+    this.assignOption(opts, 'pedantic')
+    this.assignOption(opts, 'pingInterval')
+    this.assignOption(opts, 'reconnect')
     this.assignOption(opts, 'reconnectTimeWait')
     this.assignOption(opts, 'servers')
-    this.assignOption(opts, 'urls', 'servers')
-    this.assignOption(opts, 'noRandomize')
-    this.assignOption(opts, 'NoRandomize', 'noRandomize')
-    this.assignOption(opts, 'dontRandomize', 'noRandomize')
-    this.assignOption(opts, 'encoding')
     this.assignOption(opts, 'tls')
-    this.assignOption(opts, 'secure', 'tls')
-    this.assignOption(opts, 'name')
-    this.assignOption(opts, 'client', 'name')
-    this.assignOption(opts, 'yieldTime')
-    this.assignOption(opts, 'waitOnFirstConnect')
-    this.assignOption(opts, 'preserveBuffers')
-    this.assignOption(opts, 'pingInterval')
-    this.assignOption(opts, 'maxPingOut')
+    this.assignOption(opts, 'token')
+    this.assignOption(opts, 'tokenHandler')
+    this.assignOption(opts, 'url')
     this.assignOption(opts, 'useOldRequestStyle')
+    this.assignOption(opts, 'user')
+    this.assignOption(opts, 'userCreds')
+    this.assignOption(opts, 'userJWT')
+    this.assignOption(opts, 'verbose')
+    this.assignOption(opts, 'waitOnFirstConnect')
+    this.assignOption(opts, 'yieldTime')
+
+    // fixme: aliasing a configuration property name should be an error
+    this.assignOption(opts, 'client', 'name')
+    this.assignOption(opts, 'credentials', 'userCreds')
+    this.assignOption(opts, 'dontRandomize', 'noRandomize')
+    this.assignOption(opts, 'jwt', 'userJWT')
+    this.assignOption(opts, 'JWT', 'userJWT')
+    this.assignOption(opts, 'nkeys', 'nkey')
+    this.assignOption(opts, 'NoRandomize', 'noRandomize')
+    this.assignOption(opts, 'password', 'pass')
+    this.assignOption(opts, 'secure', 'tls')
+    this.assignOption(opts, 'sig', 'nonceSigner')
+    this.assignOption(opts, 'sigCB', 'nonceSigner')
+    this.assignOption(opts, 'sigCallback', 'nonceSigner')
+    this.assignOption(opts, 'sigcb', 'nonceSigner')
+    this.assignOption(opts, 'uri', 'url')
+    this.assignOption(opts, 'urls', 'servers')
+    this.assignOption(opts, 'usercreds', 'userCreds')
+    this.assignOption(opts, 'userjwt', 'userJWT')
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.2.6",
+  "version": "0.3.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -256,12 +256,6 @@
       "version": "13.1.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.4.tgz",
       "integrity": "sha512-Lue/mlp2egZJoHXZr4LndxDAd7i/7SQYhV0EjWfb/a4/OZ6tuVwMCVPiwkU5nsEipxEf7hmkSU7Em5VQ8P5NGA==",
-      "dev": true
-    },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
@@ -650,12 +644,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -667,16 +655,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "config-chain": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
-      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
-      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -906,26 +884,6 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "editorconfig": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.5",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "emoji-regex": {
@@ -1936,12 +1894,6 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
-    },
     "inquirer": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.3.tgz",
@@ -2352,35 +2304,6 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
-    "js-beautify": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz",
-      "integrity": "sha512-ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==",
-      "dev": true,
-      "requires": {
-        "config-chain": "^1.1.12",
-        "editorconfig": "^0.15.3",
-        "glob": "^7.1.3",
-        "mkdirp": "~0.5.1",
-        "nopt": "~4.0.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2550,16 +2473,6 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -2769,16 +2682,6 @@
       "dev": true,
       "requires": {
         "process-on-spawn": "^1.0.0"
-      }
-    },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
       }
     },
     "normalize-package-data": {
@@ -3124,27 +3027,11 @@
         "wordwrap": "~1.0.0"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
     },
     "p-limit": {
       "version": "2.2.0",
@@ -3423,18 +3310,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
-    },
-    "proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
     },
     "psl": {
       "version": "1.7.0",
@@ -3774,12 +3649,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
       "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM=",
-      "dev": true
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
     "signal-exit": {
@@ -4509,12 +4378,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.3.0-0",
+  "version": "0.3.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.3.0-0",
+  "version": "0.3.0-1",
   "description": "Node.js client for NATS Streaming, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.2.6",
+  "version": "0.3.0-0",
   "description": "Node.js client for NATS Streaming, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -36,7 +36,8 @@
     "fmt": "standard --fix 'lib/stan.js' 'test/**/*.js' 'examples/*.js' 'bench/*.js'",
     "gen": "protoc --js_out=import_style=commonjs_strict,binary:. lib/pb/protocol.proto",
     "lint": "standard 'lib/stan.js' 'test/**/*.js' 'examples/*.js' 'bench/*.js'",
-    "test": "npm run depcheck && npm run depcheck:unused && npm run lint && npm run test:unit",
+    "test": "npm run depcheck && npm run depcheck:unused && npm run lint && npm run test:typescript && npm run test:unit",
+    "test:typescript": "./node_modules/typescript/bin/tsc --strict --noEmit tstest/main.ts",
     "test:unit": "mkdir -p reports/ && NODE_ENV=test multi='spec=- xunit=reports/mocha-xunit.xml' nyc mocha --timeout 10000 --slow 750",
     "wtf": "wtfnode /usr/local/bin/_mocha --timeout 10000 --slow 750"
   },

--- a/test/basics.js
+++ b/test/basics.js
@@ -873,4 +873,28 @@ describe('Basics', () => {
       })
     })
   })
+
+  it('options should be passed', (done) => {
+    // this is a garbage test that tests whether the properties are
+    // passed on actual values are wrong and would explode
+    const opts = { test_opts: true }
+    const props = ['ackTimeout', 'connectTimeout', 'discoverPrefix', 'maxPubAcksInflight', 'nc',
+      'maxReconnectAttempts', 'stanEncoding', 'stanMaxPingOut', 'stanPingInterval', 'encoding',
+      'maxPingOut', 'maxReconnectAttempts', 'name', 'nkey', 'noRandomize', 'nonceSigner', 'pass',
+      'pedantic', 'pingInterval', 'reconnect', 'reconnectTimeWait', 'servers', 'tls', 'token',
+      'tokenHandler', 'url', 'useOldRequestStyle', 'user', 'userCreds', 'userJWT', 'verbose',
+      'waitOnFirstConnect', 'yieldTime']
+
+    props.forEach((v) => {
+      opts[v] = nuid.next()
+    })
+
+    // the property 'test_opts' aborts after parse
+    const sc = STAN.connect('c', 'id', opts)
+    props.forEach((v) => {
+      sc.options[v].should.be.equal(opts[v])
+    })
+
+    done()
+  })
 })

--- a/test/basics.js
+++ b/test/basics.js
@@ -875,8 +875,8 @@ describe('Basics', () => {
   })
 
   it('options should be passed', (done) => {
-    // this is a garbage test that tests whether the properties are
-    // passed on actual values are wrong and would explode
+    // this test stuffs garbage value into options, it simply tests that
+    // values are set on the client.
     const opts = { test_opts: true }
     const props = ['ackTimeout', 'connectTimeout', 'discoverPrefix', 'maxPubAcksInflight', 'nc',
       'maxReconnectAttempts', 'stanEncoding', 'stanMaxPingOut', 'stanPingInterval', 'encoding',

--- a/tstest/main.ts
+++ b/tstest/main.ts
@@ -1,0 +1,62 @@
+import {connect, Message, StartPosition, version} from '..'
+
+console.log(version);
+
+// should allow cluster and client
+let sc = connect("cluster", "client");
+
+// should allow cluster, client and opts
+sc = connect("cluster", "client", {url: "nats://localhost:4222"});
+sc.publish('foo', 'hello world');
+sc.publish('bar', 'hi', (err, guid) => {
+    if (err) {
+        console.log(`${guid} failed with ${err}`);
+        return
+    }
+    console.log(`${guid} was published successfully`);
+
+});
+
+const so = sc.subscriptionOptions();
+so.setMaxInFlight(100);
+so.setAckWait(1000);
+so.setStartAt(StartPosition.FIRST);
+so.setStartAt(StartPosition.LAST_RECEIVED);
+so.setStartAt(StartPosition.NEW_ONLY);
+so.setStartAtSequence(1000);
+so.setStartAtTimeDelta(10000);
+so.setStartWithLastReceived();
+so.setDeliverAllAvailable();
+so.setManualAckMode(true);
+so.setDurableName('durable');
+
+let sub = sc.subscribe('foo');
+if (sub.isClosed()) {
+  console.log('sub is closed');
+}
+sub.unsubscribe();
+
+sub = sc.subscribe('bar', 'qg');
+sub.unsubscribe();
+
+sub = sc.subscribe('bar', sc.subscriptionOptions().setManualAckMode(true));
+sub.unsubscribe();
+
+sub = sc.subscribe('bar', 'queue', sc.subscriptionOptions().setDurableName('dur').setManualAckMode(true));
+sub.on('message', (msg: Message) => {
+    console.log(msg.getSubject());
+    console.log(msg.getSequence());
+    console.log(msg.getData());
+    console.log(msg.getTimestamp());
+    console.log(msg.getCrc32());
+    console.log(msg.isRedelivered());
+    msg.getTimestampRaw();
+    msg.getRawData();
+    msg.ack();
+});
+sub.close();
+sub.unsubscribe();
+
+
+
+

--- a/tstest/main.ts
+++ b/tstest/main.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 import {connect, Message, StartPosition, version} from '..'
 
 console.log(version);

--- a/tstest/main.ts
+++ b/tstest/main.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 The NATS Authors
+ * Copyright 2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
- added most nats-properties with the exception of `json`, `noEcho`, `preserveBuffers` are omitted because they don't make sense.

- updated typescript bindings
- added typescript compilation tests to validate required APIs are accessible

- changed version to be read from the package.json, this allows for npm tooling to manage the versions without breaking tests or requiring manual updates