### PR TITLE
FIX #146 - Fix docker require('../package')

### DIFF
--- a/lib/stan.js
+++ b/lib/stan.js
@@ -31,7 +31,7 @@ const url = require('url')
 /**
  * Constants
  */
-const VERSION = require('../package').version
+const VERSION = require('../package.json').version
 const DEFAULT_PORT = 4222
 const DEFAULT_PRE = 'nats://localhost:'
 const DEFAULT_URI = DEFAULT_PRE + DEFAULT_PORT

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.3.0-1",
+  "version": "0.3.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.3.0-1",
+  "version": "0.3.0-2",
   "description": "Node.js client for NATS Streaming, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -30,7 +30,7 @@
   "main": "./index.js",
   "scripts": {
     "cover": "nyc report --reporter=html && open coverage/index.html",
-    "coveralls": "npm run test && nyc report --reporter=text-lcov | coveralls",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "depcheck": "dependency-check --no-dev package.json",
     "depcheck:unused": "dependency-check package.json --no-dev --entry ./**/*.js",
     "fmt": "standard --fix 'lib/stan.js' 'test/**/*.js' 'examples/*.js' 'bench/*.js'",

--- a/test/basics.js
+++ b/test/basics.js
@@ -897,4 +897,10 @@ describe('Basics', () => {
 
     done()
   })
+
+  it('versions should match', () => {
+    const v = require('../package.json').version
+    should.exist(STAN.version)
+    v.should.be.equal(STAN.version)
+  })
 })


### PR DESCRIPTION
- When running on docker, `require('../packa…ge)` fails the require. - Changed to `require('../package.json')`

- Added a test to check the versions are properly loaded
- Removed extra npm test run when doing coveralls.