### PR TITLE
Fix partial sub

### DIFF
--- a/lib/stan.js
+++ b/lib/stan.js
@@ -679,7 +679,22 @@ Stan.prototype.subscribe = function (subject, qGroup, options) {
   }
 
   this.subMap[retVal.inbox] = retVal
-  retVal.inboxSub = this.nc.subscribe(retVal.inbox, this.processMsg())
+  retVal.inboxSub = this.nc.subscribe(retVal.inbox, (rawMsg, reply, subject) => {
+    const sub = this.subMap[subject]
+    if (!sub || !sub.ackInbox || !this.nc || sub.isClosed()) {
+      return
+    }
+
+    try {
+      // noinspection JSUnresolvedVariable
+      const m = proto.pb.MsgProto.deserializeBinary(Buffer.from(rawMsg, 'binary'))
+      const msg = new Message(this, m, sub)
+      sub.emit('message', msg)
+      msg.maybeAutoAck()
+    } catch (error) {
+      sub.emit('error', error)
+    }
+  })
   const sr = new proto.pb.SubscriptionRequest()
   sr.setClientId(this.clientID)
   sr.setSubject(subject)
@@ -868,30 +883,6 @@ Subscription.prototype.closeOrUnsubscribe = function (doClose) {
       this.emit(doClose ? 'closed' : 'unsubscribed')
     }
   })
-}
-
-/**
- * Internal function to process in-bound messages.
- * @return {Function}
- * @private
- */
-Stan.prototype.processMsg = function () {
-  // curry
-  return (rawMsg, reply, subject) => {
-    const sub = this.subMap[subject]
-    try {
-      // noinspection JSUnresolvedVariable
-      const m = proto.pb.MsgProto.deserializeBinary(Buffer.from(rawMsg, 'binary'))
-      if (sub === undefined || !this.nc) {
-        return
-      }
-      const msg = new Message(this, m, sub)
-      sub.emit('message', msg)
-      msg.maybeAutoAck()
-    } catch (error) {
-      sub.emit('error', error)
-    }
-  }
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.3.2",
+  "version": "0.3.3-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.3.3-0",
+  "version": "0.3.3-1",
   "description": "Node.js client for NATS Streaming, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-nats-streaming",
-  "version": "0.3.2",
+  "version": "0.3.3-0",
   "description": "Node.js client for NATS Streaming, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",


### PR DESCRIPTION
I inlined the handler for the streaming subscription, and then retrieve it from the map. If the subscription doesn't have the ackInbox, the message will be dropped.

This still doesn't explain how it is possible, the subscription emits `ready` only after the value from the proto is received.
FIX #186